### PR TITLE
Missing documentation on "how to test"

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -73,6 +73,14 @@ environment:
 
 See also ``make help``.
 
+****************
+Test environment
+****************
+
+To get your test environment ready, you'll need at least an access to a 9.x
+postgresql server. You may want to provide credentials, by editing the
+:file:`settings_local.sample.py` file and save it as :file:`settings_local.py`
+in the demo directory.
 
 .. rubric:: Notes & references
 

--- a/demo/django_aggtrigg_demo/settings_local.sample.py
+++ b/demo/django_aggtrigg_demo/settings_local.sample.py
@@ -1,0 +1,11 @@
+# This is a local settings example file.
+# Adapt this to fit your settings
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'django_aggtrig',
+        'USER': 'postgres',
+        'PASSWORD': 'pleaseputyournicepasswordhere',
+        'HOST': '127.0.0.1',
+    }
+}


### PR DESCRIPTION
running just "tox" is not enough. the docs may indicate how to get to a test-ready environment (databases, settings, etc).