### PR TITLE
standard verbose / non-verbose mode

### DIFF
--- a/demo/django_aggtrigg_demo/tests.py
+++ b/demo/django_aggtrigg_demo/tests.py
@@ -10,18 +10,10 @@ from django_aggtrigg.tests import AggTriggerTestMixin
 class TestCommands(TestCase):
 
     def test_commands(self):
-        out = StringIO()
-        call_command('aggtrigg_create', stdout=out)
-        out.seek(0)
-        out = StringIO()
-        call_command('aggtrigg_initialize', quiet=True, stdout=out)
-        out.seek(0)
-        out = StringIO()
-        call_command('aggtrigg_check', stdout=out)
-        out.seek(0)
-        out = StringIO()
-        call_command('aggtrigg_drop', stdout=out)
-        out.seek(0)
+        call_command('aggtrigg_create', verbosity=0)
+        call_command('aggtrigg_initialize', verbosity=0, noinput=True)
+        call_command('aggtrigg_check', verbosity=0)
+        call_command('aggtrigg_drop', verbosity=0)
 
 
 class Utils(object):
@@ -45,8 +37,8 @@ class Utils(object):
 class TestMockingTrigger(Utils, AggTriggerTestMixin, TestCase):
 
     def test_real_triggers(self):
-        call_command('aggtrigg_create')
-        call_command('aggtrigg_initialize', quiet=True)
+        call_command('aggtrigg_create', verbosity=0)
+        call_command('aggtrigg_initialize', noinput=True, verbosity=0)
         self.create_objects()
         self.unmock_get_count()
         # assert triggers are correctly set AND they retrun a correct
@@ -67,7 +59,7 @@ class TestMockingTrigger(Utils, AggTriggerTestMixin, TestCase):
         cursor = connection.cursor()
         call_command('aggtrigg_drop', stdout=out)
         cursor.execute(out.getvalue())
-        call_command('aggtrigg_check')
+        call_command('aggtrigg_check', verbosity=0)
         out = StringIO()
         call_command('aggtrigg_check', stdout=out)
         for report in out.getvalue().split("\n"):

--- a/django_aggtrigg/management/commands/aggtrigg_check.py
+++ b/django_aggtrigg/management/commands/aggtrigg_check.py
@@ -43,7 +43,9 @@ class Command(BaseCommand):
         """Handle action
         """
         trigs = djutil.get_agg_fields()
-        sys.stdout.write("--found %d triggers\n" % (len(trigs)))
+        verbosity = options.get('verbosity', 0)
+        if verbosity:
+            self.stdout.write("--found %d triggers\n" % len(trigs))
         for trig in trigs:
             self.check_trigger(trig, options)
 
@@ -71,25 +73,29 @@ class Command(BaseCommand):
                              "-- source: %s, column: %s, aggregats: %s"])
 
         if table and trig['field'] and len(aggs) > 0:
-            self.stdout.write(comment % (trig['model'], table,
-                                         trig['field'], aggs))
+            if agg.verbose:
+                self.stdout.write(comment % (trig['model'], table,
+                                             trig['field'], aggs))
             if agg.agg_table_ispresent():
-                msg = "OK table: %s is present\n" % (agg.table_name)
+                msg = "OK table: %s is present\n" % agg.table_name
             else:
-                msg = "KO table: %s is absent\n" % (agg.table_name)
+                msg = "KO table: %s is absent\n" % agg.table_name
 
-            self.stdout.write(msg)
+            if agg.verbose:
+                self.stdout.write(msg)
 
             for trig in agg.triggers_on_table_are_present():
                 if trig[1]:
-                    msg = "OK trigger: %s is present\n" % (trig[0])
+                    msg = "OK trigger: %s is present\n" % trig[0]
                 else:
-                    msg = "KO trigger: %s is absent\n" % (trig[0])
-                self.stdout.write(msg)
+                    msg = "KO trigger: %s is absent\n" % trig[0]
+                if agg.verbose:
+                    self.stdout.write(msg)
 
             for func in agg.functions_are_present():
                 if func[1]:
-                    msg = "OK function: %s is present\n" % (func[0])
+                    msg = "OK function: %s is present\n" % func[0]
                 else:
-                    msg = "KO function: %s is absent\n" % (func[0])
-                self.stdout.write(msg)
+                    msg = "KO function: %s is absent\n" % func[0]
+                if agg.verbose:
+                    self.stdout.write(msg)

--- a/django_aggtrigg/management/commands/aggtrigg_check.py
+++ b/django_aggtrigg/management/commands/aggtrigg_check.py
@@ -17,7 +17,6 @@
 #   may be used to endorse or promote products derived from this software
 #   without specific prior written permission.
 #
-import sys
 from django.core.management.base import BaseCommand
 from django.conf import settings
 from optparse import make_option

--- a/django_aggtrigg/management/commands/aggtrigg_create.py
+++ b/django_aggtrigg/management/commands/aggtrigg_create.py
@@ -52,9 +52,8 @@ class Command(BaseCommand):
                     type="string",
                     help="table name",
                     default="default"),
-        make_option("-q",
-                    "--quiet",
-                    dest="quiet",
+        make_option("--noinput",
+                    dest="noinput",
                     action="store_true",
                     default=False))
 
@@ -62,9 +61,6 @@ class Command(BaseCommand):
         """
         Handle action
         """
-        if options['quiet']:
-            options['verbosity'] = 0
-
         for trig in djutil.get_agg_fields():
             self.create_trigger(trig, options)
 

--- a/django_aggtrigg/management/commands/aggtrigg_create.py
+++ b/django_aggtrigg/management/commands/aggtrigg_create.py
@@ -17,7 +17,6 @@
 #   may be used to endorse or promote products derived from this software
 #   without specific prior written permission.
 #
-import sys
 from django.core.management.base import BaseCommand
 from django.conf import settings
 from optparse import make_option
@@ -87,14 +86,14 @@ class Command(BaseCommand):
             if not options['simulate']:
                 agg.create_objects()
                 if options['verbosity'] > 0:
-                    sys.stdout.write(comment % (table, column, aggs))
-                    sys.stdout.write("Create table : %s\n" % (agg.table_name))
+                    self.stdout.write(comment % (table, column, aggs))
+                    self.stdout.write("Create table : %s\n" % agg.table_name)
 
             #  do nothing
             else:
-                sys.stdout.write("%s\n" % (agg.sql_create_table()))
+                self.stdout.write("%s\n" % agg.sql_create_table())
                 for sql in agg.sql_create_functions():
-                    sys.stdout.write(comment % (table, column, aggs))
-                    sys.stdout.write("%s\n" % (sql))
+                    self.stdout.write(comment % (table, column, aggs))
+                    self.stdout.write("%s\n" % sql)
                 for tgs in agg.sql_create_triggers():
-                    sys.stdout.write("%s\n" % (tgs[1]))
+                    self.stdout.write("%s\n" % tgs[1])

--- a/django_aggtrigg/management/commands/aggtrigg_drop.py
+++ b/django_aggtrigg/management/commands/aggtrigg_drop.py
@@ -61,12 +61,18 @@ class Command(BaseCommand):
         table = trig['table']
 
         engine = settings.DATABASES[options['database']]['ENGINE']
+        verbosity = options.get('verbosity', 0)
 
         agg = util.AggTrigger(engine, table, column, aggs, model=model)
 
         for sqltrig in agg.sql_drop_triggers():
-            self.stdout.write("%s;\n" % (sqltrig))
+            if verbosity:
+                self.stdout.write("%s;\n" % sqltrig)
 
         for sqlfunc in agg.sql_drop_functions():
-            self.stdout.write("%s;\n" % (sqlfunc))
-        self.stdout.write("%s;\n" % (agg.sql_drop_table()))
+            if verbosity:
+                self.stdout.write("%s;\n" % sqlfunc)
+
+        drop_result = agg.sql_drop_table()
+        if verbosity:
+            self.stdout.write("%s;\n" % drop_result)

--- a/django_aggtrigg/management/commands/aggtrigg_initialize.py
+++ b/django_aggtrigg/management/commands/aggtrigg_initialize.py
@@ -34,9 +34,8 @@ class Command(BaseCommand):
                     type="string",
                     help="table name",
                     default="default"),
-        make_option("-q",
-                    "--quiet",
-                    dest="quiet",
+        make_option("--noinput",
+                    dest="noinput",
                     action="store_true",
                     default=False)
     )
@@ -70,7 +69,7 @@ class Command(BaseCommand):
                              u"%s contains %s tuples approximatively,",
                              u"maybe long : [y/N] (please type yes to do)\n"])
 
-        if options.get("quiet"):
+        if options.get("noinput", False):
             answer = "yes"
         else:
             if sys.version_info.major == 2:
@@ -79,8 +78,11 @@ class Command(BaseCommand):
                                       trig['table'],
                                       agg.get_nb_tuples()))
         if answer == "yes":
-            sys.stdout.write(" Initialize %s ...\n" % (agg.table_name))
+            if agg.verbose:
+                self.stdout.write(" Initialize %s ...\n" % agg.table_name)
             agg.initialize()
-            sys.stdout.write(" done, %s is initialized\n" % (agg.table_name))
+            if agg.verbose:
+                self.stdout.write(
+                    " done, %s is initialized\n" % agg.table_name)
         else:
             return

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ deps =
     coverage
     nose
     rednose
-    wheel
     mock
 commands =
     pip install --use-wheel -e ./


### PR DESCRIPTION
django custom command verbosity is handled via the standard "verbosity" optional argument.
we may want to use this argument to activate/deactivate the message display.

This PR changes the API a bit, especially the "no verbose / verbose / quiet" options. To sum this up:

* ``--verbosity``: handles the output verbosity. If set to ``0``, the command will be quiet and won't display logs.
* ``--noinput``: takes care of the need for input. if this option is activated, (``True``), the command won't prompt the user and will use the default answer to common questions.