### PR TITLE
Change the way we name triggers

### DIFF
--- a/demo/django_aggtrigg_demo/dummy/models.py
+++ b/demo/django_aggtrigg_demo/dummy/models.py
@@ -30,7 +30,7 @@ class Tree(models.Model):
 class Leave(models.Model):
     name = models.CharField(max_length=300)
     tree = ForeignKeyTriggerField(Tree)
-    private = models.BooleanField()
+    private = models.BooleanField(default=False)
     tree.aggregate_trigger = [
         {"count": [
             {"private_leaves": [{"field": "private", "value": True}]},

--- a/demo/django_aggtrigg_demo/settings.py
+++ b/demo/django_aggtrigg_demo/settings.py
@@ -151,6 +151,8 @@ LOGGING = {
     }
 }
 
+TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+
 try:
     from settings_local import *  # noqa
 except ImportError:

--- a/demo/django_aggtrigg_demo/tests.py
+++ b/demo/django_aggtrigg_demo/tests.py
@@ -14,6 +14,13 @@ class TestCommands(TestCase):
         call_command('aggtrigg_check', verbosity=0)
         call_command('aggtrigg_drop', verbosity=0)
 
+        out = StringIO()
+        call_command('aggtrigg_check', stdout=out)
+        for report in out.getvalue().split("\n"):
+            self.assertFalse(
+                report.startswith("KO")
+            )
+
 
 class Utils(object):
 

--- a/django_aggtrigg/util.py
+++ b/django_aggtrigg/util.py
@@ -49,9 +49,7 @@ def function_name(table, column, action, key=None):
 
 
 def trigger_name(table, column, function, action):
-    function = function[:-2]
-
-    tname = "{0}_trigger".format(function)
+    tname = "{0}_trigger".format(function[:-2])
     return tname
 
 
@@ -59,8 +57,7 @@ def triggers_name(table, column, functions):
     tgs = []
 
     for function, action in functions.iteritems():
-        function = function[:-2]
-        tgs.append("{0}_trigger".format(function))
+        tgs.append("{0}_trigger".format(function[:-2]))
     return tgs
 
 

--- a/django_aggtrigg/util.py
+++ b/django_aggtrigg/util.py
@@ -49,10 +49,9 @@ def function_name(table, column, action, key=None):
 
 
 def trigger_name(table, column, function, action):
+    function = function[:-2]
 
-    function = function.split("_")[-2][:-2]
-
-    tname = "{0}_{1}_{2}_{3}_trigger".format(table, column, function, action)
+    tname = "{0}_trigger".format(function)
     return tname
 
 
@@ -60,9 +59,8 @@ def triggers_name(table, column, functions):
     tgs = []
 
     for function, action in functions.iteritems():
-        function = function.split("_")[-1][:-2]
-        tgs.append("{0}_{1}_{2}_{3}_trigger".format(table, column,
-                                                    function, action))
+        function = function[:-2]
+        tgs.append("{0}_trigger".format(function))
     return tgs
 
 

--- a/django_aggtrigg/util_tests.py
+++ b/django_aggtrigg/util_tests.py
@@ -40,7 +40,7 @@ class utilTests(unittest.TestCase):
                          util.function_name('foo', 'colfoo', 'insert'))
 
     def test_trigger_name(self):
-        self.assertEqual("foo_id__insert_trigger",
+        self.assertEqual("foo_id_insert_trigger",
                          util.trigger_name('foo', 'id',
                                            'foo_id_insert()', 'insert'))
 
@@ -57,7 +57,7 @@ class utilTests(unittest.TestCase):
 
         tgnames = [tgn[0] for tgn in res]
         sqls = [tgn[1] for tgn in res]
-        self.assertIn("foota_foocol_fooc_insert_trigger", tgnames)
+        self.assertIn("foota_foocol_insert_trigger", tgnames)
         self.assertEqual(sqls[0][:6], "CREATE")
 
     # def test_sql_create_function(self):


### PR DESCRIPTION
For example : 
Instead of "processes_task_process_id_need_update_trigger" 
we'll get "processes_task_process_id_update_tasks_needed_company_trigger" 

See https://github.com/novafloss/django-aggtrigg/issues/68

Obviously I'll need to change some tests.